### PR TITLE
Modify Files Tab to Show Full Content

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -221,10 +221,8 @@ export default function GitHubPRAutomation() {
                         formState.data.files.map((file, index) => (
                           <div key={index} className="p-2 bg-zinc-800 rounded">
                             <div className="font-medium mb-2">{file.path}</div>
-                            <div className="text-sm text-zinc-400">
-                              {file.content.length > 100 
-                                ? file.content.substring(0, 100) + "..." 
-                                : file.content}
+                            <div className="text-sm text-zinc-400 overflow-y-auto">
+                              <pre className="whitespace-pre-wrap">{file.content}</pre>
                             </div>
                           </div>
                         ))


### PR DESCRIPTION
Prompt: currently the "Files" tab in the page.tsx card component truncates the file content text if the text is too long. I want to be able to see all of the text for each content. modify the Files tab so that it shows all the text.

- Removed content truncation in Files tab
- Added pre-wrap and scrollable container for better content display
- Modified styling to handle long content appropriately

Files modified:
- src/app/page.tsx