### PR TITLE
Update Pull Request Button State Handling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -237,7 +237,11 @@ export default function GitHubPRAutomation() {
           </CardContent>
           {formState?.success && formState?.data ? (
             <CardFooter>
-              <Button type="submit" onClick={() => handleSubmitPullRequest(formState)}>
+              <Button 
+                type="submit" 
+                onClick={() => handleSubmitPullRequest(formState)}
+                disabled={prData?.success}
+              >
                 Create Pull Request
               </Button>
             </CardFooter>


### PR DESCRIPTION
Prompt: currently, when I click the "create pull request" button, the button stays active after a successful response handleSubmitPullRequest. update the code so that the "create pull request" button changes to disabled when the response is successful. When the formState updates again, thats when I want the "create pull request" button to switch back to active.you should not need to create any new state variables. you should be able to use prData

- Modified the "Create Pull Request" button to be disabled when `prData` indicates success
- The button will be re-enabled when the form state updates again